### PR TITLE
Add test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import sqlite3
+import pytest
+
+# Ensure repo root is in sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import src.db as db
+
+@pytest.fixture
+def memory_db(monkeypatch):
+    conn = sqlite3.connect(':memory:', check_same_thread=False)
+    cursor = conn.cursor()
+    monkeypatch.setattr(db, 'conn', conn)
+    monkeypatch.setattr(db, 'cursor', cursor)
+    db.initialize_database()
+    yield db
+    conn.close()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,43 @@
+import importlib.util
+import types
+import sys
+import asyncio
+
+
+def load_base(monkeypatch, cursor, api_key='dummy'):
+    dummy_config = types.SimpleNamespace(RANDOM_ORG_API_KEY=api_key)
+    sys.modules['src.config'] = dummy_config
+    spec = importlib.util.spec_from_file_location('base', 'src/handlers/game_management/base.py')
+    base = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(base)
+    if cursor is not None:
+        monkeypatch.setattr(base, 'cursor', cursor)
+    return base
+
+
+def test_get_random_shuffle_fallback(monkeypatch):
+    base = load_base(monkeypatch, cursor=None, api_key='key')
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        def post(self, *a, **kw):
+            class Resp:
+                async def __aenter__(self_inner):
+                    raise Exception('fail')
+                async def __aexit__(self_inner, exc_type, exc, tb):
+                    pass
+            return Resp()
+
+    monkeypatch.setattr(base.aiohttp, 'ClientSession', lambda: FakeSession())
+    monkeypatch.setattr(base.random, 'sample', lambda lst, n: list(reversed(lst)))
+    result = asyncio.run(base.get_random_shuffle([1,2,3], 'key'))
+    assert result == [3,2,1]
+
+
+def test_get_templates_for_player_count(monkeypatch, memory_db):
+    base = load_base(monkeypatch, memory_db.cursor)
+    monkeypatch.setattr(base, 'role_templates', {'5': ['tpl']})
+    assert base.get_templates_for_player_count(5) == ['tpl']

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,31 @@
+import importlib.util
+import types
+import sys
+
+import src.db as db
+
+
+def load_base(monkeypatch, cursor):
+    dummy_config = types.SimpleNamespace(RANDOM_ORG_API_KEY='')
+    sys.modules['src.config'] = dummy_config
+    spec = importlib.util.spec_from_file_location('base', 'src/handlers/game_management/base.py')
+    base = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(base)
+    monkeypatch.setattr(base, 'cursor', cursor)
+    return base
+
+
+def test_initialize_database_tables(memory_db):
+    memory_db.cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {t[0] for t in memory_db.cursor.fetchall()}
+    assert {'Users', 'Games', 'Roles', 'GameRoles'} <= tables
+
+
+def test_get_player_count(memory_db, monkeypatch):
+    base = load_base(monkeypatch, memory_db.cursor)
+    game_id = 'g1'
+    memory_db.cursor.execute("INSERT INTO Games (game_id, passcode, moderator_id) VALUES (?, ?, ?)", (game_id, 'p', 1))
+    memory_db.cursor.execute("INSERT INTO Roles (game_id, user_id, role) VALUES (?, ?, ?)", (game_id, 1, 'A'))
+    memory_db.cursor.execute("INSERT INTO Roles (game_id, user_id, role) VALUES (?, ?, ?)", (game_id, 2, 'B'))
+    memory_db.conn.commit()
+    assert base.get_player_count(game_id) == 2

--- a/tests/test_passcode.py
+++ b/tests/test_passcode.py
@@ -1,0 +1,20 @@
+import ast
+
+
+def get_is_valid_passcode():
+    with open('src/handlers/passcode_handler.py', 'r') as f:
+        source = f.read()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == 'is_valid_passcode':
+            code = ast.get_source_segment(source, node)
+            namespace = {}
+            exec(code, namespace)
+            return namespace['is_valid_passcode']
+    raise RuntimeError('Function not found')
+
+
+def test_is_valid_passcode():
+    func = get_is_valid_passcode()
+    assert func('123e4567-e89b-42d3-a456-426614174000')
+    assert not func('not-a-uuid')

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,29 @@
+import json
+import importlib
+import pytest
+
+
+def reload_roles(monkeypatch, tmp_path, roles_content, templates_content):
+    roles_json = tmp_path / 'roles.json'
+    roles_json.write_text(json.dumps(roles_content))
+    templates_json = tmp_path / 'role_templates.json'
+    templates_json.write_text(json.dumps(templates_content))
+    import src.roles as roles
+    monkeypatch.setattr('src.utils.resource_path', lambda p: roles_json if 'roles.json' in p else templates_json)
+    importlib.reload(roles)
+    return roles
+
+
+def test_load_roles(monkeypatch, tmp_path):
+    roles_content = {"roles": [{"name": "A", "description": "desc", "faction": "F"}]}
+    templates_content = {"templates": {"1": [{"name": "t1", "roles": {"A": 1}}]}, "pending_templates": {}}
+    roles = reload_roles(monkeypatch, tmp_path, roles_content, templates_content)
+    assert roles.available_roles == ['A']
+    assert roles.role_descriptions['A'] == 'desc'
+    assert roles.role_templates == {"1": [{"name": "t1", "roles": {"A": 1}}]}
+    assert roles.pending_templates == {}
+
+    roles.save_role_templates({'x': [1]}, {'y': []})
+    saved = json.loads((tmp_path / 'role_templates.json').read_text())
+    assert saved['templates'] == {'x': [1]}
+    assert saved['pending_templates'] == {'y': []}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import os
+from src.utils import resource_path, generate_voting_summary
+
+def test_resource_path():
+    path = resource_path(os.path.join('data', 'roles.json'))
+    assert os.path.isabs(path)
+    assert path.endswith(os.path.join('data', 'roles.json'))
+
+def test_generate_voting_summary():
+    summary = generate_voting_summary(['Alice'], ['Bob'])
+    assert 'Alice' in summary
+    assert 'Bob' in summary
+    assert 'Players Who Have Voted' in summary


### PR DESCRIPTION
## Summary
- add pytest fixtures and unit tests for utils and database helpers
- cover roles loading utilities and base helper functions
- verify uuid passcode validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501518c904832a88d56f9649d4c231