### PR TITLE
Add more unit tests

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -41,3 +41,44 @@ def test_get_templates_for_player_count(monkeypatch, memory_db):
     base = load_base(monkeypatch, memory_db.cursor)
     monkeypatch.setattr(base, 'role_templates', {'5': ['tpl']})
     assert base.get_templates_for_player_count(5) == ['tpl']
+
+
+
+def test_get_random_shuffle_success(monkeypatch):
+    base = load_base(monkeypatch, cursor=None, api_key='key')
+
+    class FakeResponse:
+        def __init__(self):
+            self.status = 200
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def json(self):
+            return {"result": {"random": {"data": [[3, 1, 2]]}}}
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        def post(self, *a, **kw):
+            return FakeResponse()
+
+    monkeypatch.setattr(base.aiohttp, 'ClientSession', lambda: FakeSession())
+    result = asyncio.run(base.get_random_shuffle([1, 2, 3], 'key'))
+    assert result == [3, 1, 2]
+
+
+def test_get_random_shuffle_empty_no_call(monkeypatch):
+    base = load_base(monkeypatch, cursor=None, api_key='key')
+
+    class ShouldNotBeCalled:
+        def __init__(self, *a, **kw):
+            raise AssertionError("ClientSession should not be called")
+
+    monkeypatch.setattr(base.aiohttp, 'ClientSession', ShouldNotBeCalled)
+    monkeypatch.setattr(base.random, 'sample', lambda *a, **k: (_ for _ in ()).throw(AssertionError("sample called")))
+
+    result = asyncio.run(base.get_random_shuffle([], 'key'))
+    assert result == []

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -29,3 +29,19 @@ def test_get_player_count(memory_db, monkeypatch):
     memory_db.cursor.execute("INSERT INTO Roles (game_id, user_id, role) VALUES (?, ?, ?)", (game_id, 2, 'B'))
     memory_db.conn.commit()
     assert base.get_player_count(game_id) == 2
+
+
+def test_initialize_columns(memory_db):
+    memory_db.cursor.execute("PRAGMA table_info(Roles)")
+    role_cols = [c[1] for c in memory_db.cursor.fetchall()]
+    assert 'eliminated' in role_cols
+
+    memory_db.cursor.execute("PRAGMA table_info(Games)")
+    game_cols = [c[1] for c in memory_db.cursor.fetchall()]
+    assert 'randomness_method' in game_cols
+
+    memory_db.cursor.execute("INSERT INTO Games (game_id, passcode, moderator_id) VALUES (?, ?, ?)", ('g', 'p', 1))
+    memory_db.cursor.execute("INSERT INTO Roles (game_id, user_id, role) VALUES (?, ?, ?)", ('g', 1, 'A'))
+    memory_db.conn.commit()
+    memory_db.cursor.execute("SELECT eliminated FROM Roles WHERE game_id=? AND user_id=?", ('g', 1))
+    assert memory_db.cursor.fetchone()[0] == 0

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -27,3 +27,13 @@ def test_load_roles(monkeypatch, tmp_path):
     saved = json.loads((tmp_path / 'role_templates.json').read_text())
     assert saved['templates'] == {'x': [1]}
     assert saved['pending_templates'] == {'y': []}
+
+
+def test_load_role_factions(monkeypatch, tmp_path):
+    roles_content = {"roles": [
+        {"name": "A", "description": "desc", "faction": "F1"},
+        {"name": "B", "description": "desc2", "faction": "F2"}
+    ]}
+    templates_content = {"templates": {}, "pending_templates": {}}
+    roles = reload_roles(monkeypatch, tmp_path, roles_content, templates_content)
+    assert roles.role_factions == {"A": "F1", "B": "F2"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,3 +11,8 @@ def test_generate_voting_summary():
     assert 'Alice' in summary
     assert 'Bob' in summary
     assert 'Players Who Have Voted' in summary
+
+
+def test_generate_voting_summary_empty():
+    summary = generate_voting_summary([], [])
+    assert 'None' in summary


### PR DESCRIPTION
## Summary
- create `db/.gitkeep` so SQLite can create database file at import time
- expand tests for Random.org shuffle including success and empty list cases
- test role faction loading
- verify DB schema columns and defaults
- test empty voting summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501800cf1c832a991919cf37d7f8bd